### PR TITLE
Remove markdown-it-named-headers dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,9 +17,8 @@
         "markdown-it-checkbox": "^1.1.0",
         "markdown-it-container": "^2.0.0",
         "markdown-it-emoji": "^1.4.0",
-        "markdown-it-include": "^2.0.0",
-        "markdown-it-named-headers": "0.0.4",
-        "markdown-it-plantuml": "^1.4.1",
+  "markdown-it-include": "^2.0.0",
+  "markdown-it-plantuml": "^1.4.1",
         "mkdirp": "^1.0.3",
         "mustache": "^4.0.1",
         "puppeteer-core": "^2.1.1",
@@ -588,15 +587,6 @@
       },
       "peerDependencies": {
         "markdown-it": ">=8.4.2"
-      }
-    },
-    "node_modules/markdown-it-named-headers": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/markdown-it-named-headers/-/markdown-it-named-headers-0.0.4.tgz",
-      "integrity": "sha512-2uuJ9urchbulz9F7q6VVQmeGxSXjxFeeGcb4ebKiz3+nuKOho1rLw8866a6zs1EeAe9xdSOKEpqeF5Dv22ZDxw==",
-      "license": "Unlicense",
-      "dependencies": {
-        "string": "^3.0.1"
       }
     },
     "node_modules/markdown-it-plantuml": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "markdown-it-container": "^2.0.0",
     "markdown-it-emoji": "^1.4.0",
     "markdown-it-include": "^2.0.0",
-    "markdown-it-named-headers": "0.0.4",
     "markdown-it-plantuml": "^1.4.1",
     "mkdirp": "^1.0.3",
     "mustache": "^4.0.1",


### PR DESCRIPTION
## Summary
- replace the markdown-it-named-headers plugin with a custom heading ID helper (ported from microsoft/vscode@9e017425b3d38cfc2d31a7375a28ff6d833ea4ae)
- drop the markdown-it-named-headers dependency from package.json and package-lock.json
- keep heading IDs stable by slugifying titles and appending numeric suffixes when duplicates occur

## Testing
- `npm run start -- README.md --type html --output ./tmp-output`
