### PR TITLE
feat: configurable browser and puppeteer runtime support

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,5 +65,6 @@ markdown-pdf-m docs/design.md --config ./markdown-pdf.config.json --output ./dis
 ## Notes
 
 - Chromium/Chrome is downloaded automatically if no executable is available. To reuse an existing installation, set `markdownPdf.browser.executablePath` (or the legacy `markdownPdf.executablePath`).
+- Set `markdownPdf.browser.puppeteerCore` to `"legacy"` to run with `puppeteer-core@2.1.1` (useful for older Chromium builds such as `722234`). Leave it as `"modern"` (default) to keep using the latest Puppeteer runtime.
 - To pin a specific browser build, provide `markdownPdf.browser.name` (`chrome`, `chromium`, or `chrome-headless-shell`) and `markdownPdf.browser.version` (for example `"stable"`, `"canary"`, or an explicit version like `"141.0.7390.54"`). The CLI will download and cache the requested build automatically.
 - Proxy settings can be provided through `http.proxy` in the configuration file.

--- a/README.md
+++ b/README.md
@@ -64,5 +64,6 @@ markdown-pdf-m docs/design.md --config ./markdown-pdf.config.json --output ./dis
 
 ## Notes
 
-- Chromium is downloaded automatically if no executable is available. Set `markdownPdf.executablePath` in your config to reuse an existing Chrome/Chromium installation.
+- Chromium/Chrome is downloaded automatically if no executable is available. To reuse an existing installation, set `markdownPdf.browser.executablePath` (or the legacy `markdownPdf.executablePath`).
+- To pin a specific browser build, provide `markdownPdf.browser.name` (`chrome`, `chromium`, or `chrome-headless-shell`) and `markdownPdf.browser.version` (for example `"stable"`, `"canary"`, or an explicit version like `"141.0.7390.54"`). The CLI will download and cache the requested build automatically.
 - Proxy settings can be provided through `http.proxy` in the configuration file.

--- a/config/defaults.json
+++ b/config/defaults.json
@@ -23,6 +23,13 @@
     "mermaidServer": "https://unpkg.com/mermaid/dist/mermaid.min.js",
     "StatusbarMessageTimeout": 10000,
     "executablePath": "",
+    "browser": {
+      "name": "chrome",
+      "version": "",
+      "channel": "",
+      "cacheDir": "",
+      "executablePath": ""
+    },
     "orientation": "portrait",
     "scale": 1,
     "displayHeaderFooter": true,

--- a/config/defaults.json
+++ b/config/defaults.json
@@ -27,6 +27,7 @@
       "name": "chrome",
       "version": "",
       "channel": "",
+      "puppeteerCore": "modern",
       "cacheDir": "",
       "executablePath": ""
     },

--- a/index.js
+++ b/index.js
@@ -15,7 +15,6 @@ const mkdirp = require('mkdirp');
 const mustache = require('mustache');
 const rimraf = require('rimraf');
 
-const puppeteer = require('puppeteer-core');
 const {
   install: installBrowser,
   Browser,
@@ -23,16 +22,42 @@ const {
   resolveBuildId,
   getInstalledBrowsers
 } = require('@puppeteer/browsers');
-const { PUPPETEER_REVISIONS } = require('puppeteer-core/lib/cjs/puppeteer/revisions.js');
 
 const DEFAULT_CONFIG_FILE = path.join(__dirname, 'config', 'defaults.json');
 const USER_CONFIG_CANDIDATE = 'markdown-pdf.config.json';
 const SUPPORTED_TYPES = ['html', 'pdf', 'png', 'jpeg'];
 const BROWSER_CACHE_DIR = path.join(os.homedir(), '.cache', 'markdown-pdf-m-cli');
 const DEFAULT_BROWSER_NAME = 'chrome';
+const DEFAULT_PUPPETEER_VARIANT = 'modern';
+
+const PUPPETEER_VARIANTS = {
+  modern: {
+    id: 'modern',
+    label: 'puppeteer-core@^24.23.0',
+    requireModule: () => require('puppeteer-core'),
+    requireRevisions: () => require('puppeteer-core/lib/cjs/puppeteer/revisions.js').PUPPETEER_REVISIONS
+  },
+  legacy: {
+    id: 'legacy',
+    label: 'puppeteer-core@2.1.1',
+    requireModule: () => require('puppeteer-core-v2'),
+    requireRevisions: () => {
+      const pkg = require('puppeteer-core-v2/package.json');
+      const revision = pkg?.puppeteer?.chromium_revision;
+      if (!revision) {
+        return {};
+      }
+      return {
+        chromium: revision,
+        chrome: revision,
+        'chrome-headless-shell': revision
+      };
+    }
+  }
+};
 
 let INSTALL_CHECK = false;
-let cachedExecutablePath = null;
+const cachedExecutables = new Map();
 
 function getBrowserCacheDir(customDir) {
   if (typeof customDir === 'string' && customDir.trim().length > 0) {
@@ -60,6 +85,55 @@ function resolveExecutableOverride(customPath) {
     }
   }
   return null;
+}
+
+function normalizeVariantKey(value) {
+  if (!value) {
+    return DEFAULT_PUPPETEER_VARIANT;
+  }
+  const normalized = String(value).trim().toLowerCase();
+  switch (normalized) {
+    case 'modern':
+    case 'latest':
+    case 'current':
+      return 'modern';
+    case 'legacy':
+    case 'v2':
+    case '2':
+    case 'puppeteer@2':
+    case 'puppeteer-core@2':
+    case '2.1.1':
+    case 'old':
+      return 'legacy';
+    default:
+      return normalized;
+  }
+}
+
+function resolvePuppeteerVariant(markdownPdfConfig) {
+  const browserConfig = isPlainObject(markdownPdfConfig?.browser) ? markdownPdfConfig.browser : {};
+  const envPreference = process.env.MARKDOWN_PDF_PUPPETEER_VARIANT || process.env.MARKDOWN_PDF_PUPPETEER_CORE;
+  const preference = pickFirstNonEmptyString(browserConfig.puppeteerCore, browserConfig.puppeteerVariant, browserConfig.runtime, envPreference, DEFAULT_PUPPETEER_VARIANT);
+  const key = normalizeVariantKey(preference);
+  const variant = PUPPETEER_VARIANTS[key] || PUPPETEER_VARIANTS[DEFAULT_PUPPETEER_VARIANT];
+  if (!variant.module) {
+    variant.module = variant.requireModule();
+  }
+  if (!variant.revisions) {
+    variant.revisions = variant.requireRevisions();
+  }
+  return {
+    id: variant.id,
+    label: variant.label,
+    module: variant.module,
+    revisions: variant.revisions
+  };
+}
+
+function computeCacheKey(variantId, browserName, requestedTag, cacheDir) {
+  const tagPart = requestedTag && requestedTag.length > 0 ? requestedTag : 'default';
+  const cachePart = cacheDir && cacheDir.length > 0 ? `:${path.resolve(cacheDir)}` : '';
+  return `${variantId}:${browserName}:${tagPart}${cachePart}`;
 }
 
 function pickFirstNonEmptyString(...values) {
@@ -91,7 +165,7 @@ function mapBrowserNameToEnum(name) {
   }
 }
 
-function normalizeBrowserOptions(markdownPdfConfig) {
+function normalizeBrowserOptions(markdownPdfConfig, puppeteerVariant) {
   const browserConfig = isPlainObject(markdownPdfConfig?.browser) ? markdownPdfConfig.browser : {};
   const nameInput = pickFirstNonEmptyString(browserConfig.name, DEFAULT_BROWSER_NAME);
   const versionTag = pickFirstNonEmptyString(browserConfig.version, browserConfig.buildId, browserConfig.revision);
@@ -106,11 +180,13 @@ function normalizeBrowserOptions(markdownPdfConfig) {
     cacheDir,
     executablePath,
     displayName: (nameInput || DEFAULT_BROWSER_NAME).toLowerCase(),
-    originalTag: requestedTag
+    originalTag: requestedTag,
+    variantId: puppeteerVariant?.id || DEFAULT_PUPPETEER_VARIANT,
+    revisions: puppeteerVariant?.revisions || {}
   };
 }
 
-async function resolveBrowserBuild(browserOptions, platform) {
+async function resolveBrowserBuild(browserOptions, platform, revisionsMap) {
   const requestedTag = browserOptions.requestedTag;
   if (requestedTag) {
     const resolved = await resolveBuildId(browserOptions.browser, platform, requestedTag);
@@ -132,7 +208,7 @@ async function resolveBrowserBuild(browserOptions, platform) {
     return { buildId: latest, alias: 'latest' };
   }
 
-  const defaultRevision = PUPPETEER_REVISIONS[browserOptions.browser] || PUPPETEER_REVISIONS[DEFAULT_BROWSER_NAME];
+  const defaultRevision = revisionsMap?.[browserOptions.browser] || revisionsMap?.[DEFAULT_BROWSER_NAME];
   if (!defaultRevision) {
     throw new Error(`No default revision available for browser "${browserOptions.browser}". Please configure "markdownPdf.browser.version".`);
   }
@@ -363,7 +439,9 @@ async function exportDocument(html, inputPath, type, outputDirOverride, config) 
   }
 
   const markdownPdfConfig = config?.markdownPdf || {};
-  const executablePath = await ensureChromium(markdownPdfConfig, config);
+  const puppeteerVariant = resolvePuppeteerVariant(markdownPdfConfig);
+  const puppeteerModule = puppeteerVariant.module;
+  const executablePath = await ensureChromium(markdownPdfConfig, config, puppeteerVariant);
 
   const tmpFile = path.join(path.dirname(targetPath), `${path.basename(targetPath, '.' + type)}_tmp.html`);
   fs.writeFileSync(tmpFile, html, 'utf-8');
@@ -373,7 +451,7 @@ async function exportDocument(html, inputPath, type, outputDirOverride, config) 
     args: [`--lang=${detectLanguage(config)}`, '--no-sandbox', '--disable-setuid-sandbox']
   };
 
-  const browser = await puppeteer.launch(launchOptions);
+  const browser = await puppeteerModule.launch(launchOptions);
   const page = await browser.newPage();
   await page.setDefaultTimeout(0);
   await page.goto(pathToFileURL(tmpFile).toString(), { waitUntil: 'networkidle0' });
@@ -399,33 +477,39 @@ function detectLanguage(config) {
   return config?.language || process.env.LANG || process.env.LANGUAGE || 'en-US';
 }
 
-async function ensureChromium(markdownPdfConfig, config) {
-  const browserOptions = normalizeBrowserOptions(markdownPdfConfig);
+async function ensureChromium(markdownPdfConfig, config, puppeteerVariant) {
+  const browserOptions = normalizeBrowserOptions(markdownPdfConfig, puppeteerVariant);
   const overridePath = resolveExecutableOverride(browserOptions.executablePath);
   if (overridePath) {
     INSTALL_CHECK = true;
-    cachedExecutablePath = overridePath;
-    return cachedExecutablePath;
+    return overridePath;
   }
 
-  if (cachedExecutablePath && fs.existsSync(cachedExecutablePath)) {
+  const cacheKey = computeCacheKey(browserOptions.variantId, browserOptions.browser, browserOptions.requestedTag, browserOptions.cacheDir);
+  const cachedPath = cachedExecutables.get(cacheKey);
+  if (cachedPath && fs.existsSync(cachedPath)) {
     INSTALL_CHECK = true;
-    return cachedExecutablePath;
+    return cachedPath;
+  }
+  if (cachedPath && !fs.existsSync(cachedPath)) {
+    cachedExecutables.delete(cacheKey);
   }
 
   try {
-    const bundled = puppeteer.executablePath();
+    const executablePathFn = puppeteerVariant.module?.executablePath;
+    const bundled = typeof executablePathFn === 'function' ? executablePathFn() : null;
     if (bundled && fs.existsSync(bundled)) {
       INSTALL_CHECK = true;
-      cachedExecutablePath = bundled;
-      return cachedExecutablePath;
+      cachedExecutables.set(cacheKey, bundled);
+      return bundled;
     }
   } catch (error) {
     // ignore and attempt installation below
   }
 
-  cachedExecutablePath = await installChromium(config, browserOptions);
-  return cachedExecutablePath;
+  const installedPath = await installChromium(config, browserOptions);
+  cachedExecutables.set(cacheKey, installedPath);
+  return installedPath;
 }
 
 async function installChromium(config, browserOptions) {
@@ -435,7 +519,7 @@ async function installChromium(config, browserOptions) {
   if (!platform) {
     throw new Error('Unsupported platform for browser download.');
   }
-  const { buildId, alias } = await resolveBrowserBuild(browserOptions, platform);
+  const { buildId, alias } = await resolveBrowserBuild(browserOptions, platform, browserOptions.revisions);
   const label = formatBrowserLabel(browserOptions, buildId, alias);
 
   const cacheDir = getBrowserCacheDir(browserOptions.cacheDir);

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "mkdirp": "^1.0.3",
         "mustache": "^4.0.1",
         "puppeteer-core": "^24.23.0",
+        "puppeteer-core-v2": "npm:puppeteer-core@2.1.1",
         "rimraf": "^3.0.2"
       },
       "bin": {
@@ -54,6 +55,12 @@
       "version": "0.23.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
       "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/mime-types": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@types/mime-types/-/mime-types-2.1.4.tgz",
+      "integrity": "sha512-lfU4b34HOri+kAY5UheuFMWPDOI+OPceBSHZKp69gEyTL/mmJ4cnU6Y/rlme3UL3GyOn6Y42hyIEw0/q8sWx5w==",
       "license": "MIT"
     },
     "node_modules/@types/node": {
@@ -129,6 +136,12 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/async-limiter": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
+      "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
+      "license": "MIT"
     },
     "node_modules/b4a": {
       "version": "1.7.3",
@@ -267,6 +280,12 @@
         "node": "*"
       }
     },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "license": "MIT"
+    },
     "node_modules/cheerio": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.1.2.tgz",
@@ -358,6 +377,27 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "license": "MIT"
+    },
+    "node_modules/concat-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "engines": [
+        "node >= 0.8"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      }
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "license": "MIT"
     },
     "node_modules/css-select": {
@@ -853,6 +893,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
     "node_modules/js-yaml": {
       "version": "3.14.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
@@ -972,6 +1018,39 @@
       "integrity": "sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g==",
       "license": "MIT"
     },
+    "node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -982,6 +1061,15 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/mitt": {
@@ -1143,6 +1231,12 @@
       "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
       "license": "MIT"
     },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
+    },
     "node_modules/progress": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
@@ -1205,6 +1299,129 @@
         "node": ">=18"
       }
     },
+    "node_modules/puppeteer-core-v2": {
+      "name": "puppeteer-core",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-2.1.1.tgz",
+      "integrity": "sha512-n13AWriBMPYxnpbb6bnaY5YoY6rGj8vPLrz6CZF3o0qJNEwlcfJVxBzYZ0NJsQ21UbdJoijPCDrM++SUVEz7+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/mime-types": "^2.1.0",
+        "debug": "^4.1.0",
+        "extract-zip": "^1.6.6",
+        "https-proxy-agent": "^4.0.0",
+        "mime": "^2.0.3",
+        "mime-types": "^2.1.25",
+        "progress": "^2.0.1",
+        "proxy-from-env": "^1.0.0",
+        "rimraf": "^2.6.1",
+        "ws": "^6.1.0"
+      },
+      "engines": {
+        "node": ">=8.16.0"
+      }
+    },
+    "node_modules/puppeteer-core-v2/node_modules/agent-base": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-5.1.1.tgz",
+      "integrity": "sha512-TMeqbNl2fMW0nMjTEPOwe3J/PRFP4vqeoNuQMG0HlMrtm5QxKqdvAkZ1pRBQ/ulIyDD5Yq0nJ7YbdD8ey0TO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/puppeteer-core-v2/node_modules/extract-zip": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.7.0.tgz",
+      "integrity": "sha512-xoh5G1W/PB0/27lXgMQyIhP5DSY/LhoCsOyZgb+6iMmRtCwVBo55uKaMoEYrDCKQhWvqEip5ZPKAc6eFNyf/MA==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "concat-stream": "^1.6.2",
+        "debug": "^2.6.9",
+        "mkdirp": "^0.5.4",
+        "yauzl": "^2.10.0"
+      },
+      "bin": {
+        "extract-zip": "cli.js"
+      }
+    },
+    "node_modules/puppeteer-core-v2/node_modules/extract-zip/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/puppeteer-core-v2/node_modules/https-proxy-agent": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-4.0.0.tgz",
+      "integrity": "sha512-zoDhWrkR3of1l9QAL8/scJZyLu8j/gBkcwcaQOZh7Gyh/+uJQzGVETdgT30akuwkpL8HTRfssqI3BZuV18teDg==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "5",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/puppeteer-core-v2/node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/puppeteer-core-v2/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/puppeteer-core-v2/node_modules/rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "node_modules/puppeteer-core-v2/node_modules/ws": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.3.tgz",
+      "integrity": "sha512-jmTjYU0j60B+vHey6TfR3Z7RD61z/hmxBS3VMSGIrroOWXQEneK1zNuotOUrGyBHQj0yrpsLHPWtigEFd13ndA==",
+      "license": "MIT",
+      "dependencies": {
+        "async-limiter": "~1.0.0"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -1229,6 +1446,12 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -1326,6 +1549,15 @@
         "text-decoder": "^1.1.0"
       }
     },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -1407,6 +1639,12 @@
       "integrity": "sha512-SbklCd1F0EiZOyPiW192rrHZzZ5sBijB6xM+cpmrwDqObvdtunOHHIk9fCGsoK5JVIYXoyEp4iEdE3upFH3PAg==",
       "license": "MIT"
     },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "license": "MIT"
+    },
     "node_modules/uc.micro": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
@@ -1434,6 +1672,12 @@
       "integrity": "sha512-QQiYxHuyZ9gQUIrmPo3IA+hUl4KYk8uSA7cHrcKd/l3p1OTpZcM0Tbp9x7FAtXdAYhlasd60ncPpgu6ihG6TOA==",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/webdriver-bidi-protocol": {
       "version": "0.3.6",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "mkdirp": "^1.0.3",
     "mustache": "^4.0.1",
     "puppeteer-core": "^24.23.0",
+    "puppeteer-core-v2": "npm:puppeteer-core@2.1.1",
     "rimraf": "^3.0.2"
   }
 }


### PR DESCRIPTION
## Summary
- add configuration-driven browser selection with build pinning, cache overrides, and executable fallbacks
- introduce modern/legacy puppeteer-core runtime switching and reuse cached downloads per variant
- document new settings and ship npm alias for puppeteer-core@2.1.1

## Testing
- npm run start -- README.md --type html --output ./tmp-output
- npm run start -- README.md --type pdf --config ./tmp-legacy-config.json
- npm run start -- D:\m\DOC\DOC_【PJ外秘】製品00098_機能説明書md_20250929_C473444_pick_pw_shimizu\【PJ外秘】製品00098_機能説明書md\403_看護プロフィール\403_機能説明書_看護プロフィール.md --config D:\m\DOC\markdown-pdf_m80.config.json --type pdf