### PR TITLE
Update Markdown dependencies and front matter parsing

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,12 +8,12 @@ const url = require('url');
 const { pathToFileURL } = require('url');
 
 const cheerio = require('cheerio');
-const grayMatter = require('gray-matter');
 const highlightJs = require('highlight.js');
 const markdownIt = require('markdown-it');
 const mkdirp = require('mkdirp');
 const mustache = require('mustache');
 const rimraf = require('rimraf');
+const yaml = require('yaml');
 
 const {
   install: installBrowser,
@@ -33,7 +33,7 @@ const DEFAULT_PUPPETEER_VARIANT = 'modern';
 const PUPPETEER_VARIANTS = {
   modern: {
     id: 'modern',
-    label: 'puppeteer-core@^25.4.0',
+    label: 'puppeteer-core@^25.6.0',
     requireModule: () => require('puppeteer-core'),
     requireRevisions: () => require('puppeteer-core/lib/puppeteer/revisions.js').PUPPETEER_REVISIONS
   },
@@ -563,7 +563,7 @@ async function installChromium(config, browserOptions) {
 
 function convertMarkdownToHtml(filename, type, text, config) {
   const markdownPdfConfig = config?.markdownPdf || {};
-  const matterParts = grayMatter(text);
+  const matterParts = parseFrontMatter(text);
 
   const md = markdownIt({
     html: true,
@@ -678,6 +678,22 @@ function convertMarkdownToHtml(filename, type, text, config) {
   }
 
   return md.render(matterParts.content);
+}
+
+function parseFrontMatter(text) {
+  const matterParts = {
+    data: {},
+    content: text
+  };
+  const frontMatter = /^---\r?\n([\s\S]*?)^---(?:\r?\n|$)/m.exec(text);
+
+  if (!frontMatter) {
+    return matterParts;
+  }
+
+  matterParts.data = yaml.parse(frontMatter[1]) || {};
+  matterParts.content = text.slice(frontMatter[0].length);
+  return matterParts;
 }
 
 function makeHtml(data, inputPath, config) {
@@ -1041,6 +1057,7 @@ module.exports = {
   normalizeDimension,
   normalizeVariantKey,
   parseArgs,
+  parseFrontMatter,
   resolveOutputPath,
   resolvePuppeteerVariant,
   resolveTypes,

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,10 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@puppeteer/browsers": "^3.0.6",
-        "cheerio": "^1.0.0-rc.12",
+        "cheerio": "^1.2.0",
         "emoji-images": "^0.1.1",
-        "gray-matter": "^4.0.2",
-        "highlight.js": "^11.11.1",
-        "markdown-it": "^14.2.0",
+        "highlight.js": "^11.12.0",
+        "markdown-it": "^14.3.0",
         "markdown-it-checkbox": "^1.1.0",
         "markdown-it-container": "^2.0.0",
         "markdown-it-emoji": "^1.4.0",
@@ -22,21 +20,22 @@
         "markdown-it-plantuml": "^1.4.1",
         "mkdirp": "^1.0.3",
         "mustache": "^4.0.1",
-        "puppeteer-core": "^25.4.0",
+        "puppeteer-core": "^25.6.0",
         "puppeteer-core-v2": "npm:puppeteer-core@2.1.1",
-        "rimraf": "^6.1.3"
+        "rimraf": "^6.1.3",
+        "yaml": "^2.8.1"
       },
       "bin": {
         "markdown-pdf-m": "index.js"
       }
     },
     "node_modules/@puppeteer/browsers": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-3.0.6.tgz",
-      "integrity": "sha512-B/gKoqlFkzhvzsI6jo9K1cZz9o5ypviVv/xu8CwA4grZzyVwN+XfkT+tu8T1zrauuEXv6VhS2oGX+6NL95WcKA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-3.2.0.tgz",
+      "integrity": "sha512-LlBrE8oqGfU7b1Nk2d5Q1SbuPhZxTj0cJEMDPEws28OjNMELlflekmPPuf4FnK03x0ZRjKaYwJElUcKK4kyqJA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "modern-tar": "^0.7.6",
+        "modern-tar": "^0.8.0",
         "yargs": "^18.0.0"
       },
       "bin": {
@@ -65,9 +64,9 @@
       "license": "MIT"
     },
     "node_modules/ansi-regex": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
-      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+      "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -86,15 +85,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "license": "MIT",
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
       }
     },
     "node_modules/async-limiter": {
@@ -141,9 +131,9 @@
       "license": "MIT"
     },
     "node_modules/cheerio": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.1.2.tgz",
-      "integrity": "sha512-IkxPpb5rS/d1IiLbHMgfPuS0FgiWTtFIm/Nj+2woXDLTZ7fOT2eqzgYbdMlLweqlHbsZjxEChoVK+7iph7jyQg==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.2.0.tgz",
+      "integrity": "sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg==",
       "license": "MIT",
       "dependencies": {
         "cheerio-select": "^2.1.0",
@@ -151,11 +141,11 @@
         "domhandler": "^5.0.3",
         "domutils": "^3.2.2",
         "encoding-sniffer": "^0.2.1",
-        "htmlparser2": "^10.0.0",
+        "htmlparser2": "^10.1.0",
         "parse5": "^7.3.0",
         "parse5-htmlparser2-tree-adapter": "^7.1.0",
         "parse5-parser-stream": "^7.1.2",
-        "undici": "^7.12.0",
+        "undici": "^7.19.0",
         "whatwg-mimetype": "^4.0.0"
       },
       "engines": {
@@ -407,31 +397,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/esprima": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "license": "BSD-2-Clause",
-      "bin": {
-        "esparse": "bin/esparse.js",
-        "esvalidate": "bin/esvalidate.js"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/extend-shallow": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
-      "license": "MIT",
-      "dependencies": {
-        "is-extendable": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/fd-slicer": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
@@ -489,34 +454,19 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/gray-matter": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.3.tgz",
-      "integrity": "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==",
-      "license": "MIT",
-      "dependencies": {
-        "js-yaml": "^3.13.1",
-        "kind-of": "^6.0.2",
-        "section-matter": "^1.0.0",
-        "strip-bom-string": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=6.0"
-      }
-    },
     "node_modules/highlight.js": {
-      "version": "11.11.1",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
-      "integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
+      "version": "11.12.0",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.12.0.tgz",
+      "integrity": "sha512-nbfWpyRMcMrPMmDwJB+dhX/eiaPKtc2RB+0QZskqJ3WjRA/FDS0e9hZrx8EC/lbEv8gXy98FcDbNa/dspAaJMg==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=12.0.0"
       }
     },
     "node_modules/htmlparser2": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.0.0.tgz",
-      "integrity": "sha512-TwAZM+zE5Tq3lrEHvOlvwgj1XLWQCtaaibSN11Q+gGBAS7Y1uZSWwXXRe4iF6OXnaq1riyQAPFOBtYc77Mxq0g==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
+      "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
       "funding": [
         "https://github.com/fb55/htmlparser2?sponsor=1",
         {
@@ -528,14 +478,14 @@
       "dependencies": {
         "domelementtype": "^2.3.0",
         "domhandler": "^5.0.3",
-        "domutils": "^3.2.1",
-        "entities": "^6.0.0"
+        "domutils": "^3.2.2",
+        "entities": "^7.0.1"
       }
     },
     "node_modules/htmlparser2/node_modules/entities": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
-      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
@@ -573,42 +523,11 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
     },
-    "node_modules/is-extendable": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
       "license": "MIT"
-    },
-    "node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
-    "node_modules/kind-of": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/linkify-it": {
       "version": "5.0.2",
@@ -639,9 +558,9 @@
       }
     },
     "node_modules/markdown-it": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.2.0.tgz",
-      "integrity": "sha512-1TGiQiJVRQ3NPmZH6sx5Cfnmg6GQm9jvC1ch4TK511NjSJvjzKLzn5pPfZRNZkRPZP0HqCioSndqH8v2nRaWVQ==",
+      "version": "14.3.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.3.0.tgz",
+      "integrity": "sha512-RCEsPjR+sr0x+AuYp601tKTkgFG4YEPLCzHST3cQ/fhlJkqAkz1L2/Qbp1j9qw5SBwQHFBoW8+hoN5xssOF0Tw==",
       "funding": [
         {
           "type": "github",
@@ -655,8 +574,8 @@
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1",
-        "entities": "^4.4.0",
-        "linkify-it": "^5.0.1",
+        "entities": "^4.5.0",
+        "linkify-it": "^5.0.2",
         "mdurl": "^2.0.0",
         "punycode.js": "^2.3.1",
         "uc.micro": "^2.1.0"
@@ -798,9 +717,9 @@
       }
     },
     "node_modules/modern-tar": {
-      "version": "0.7.7",
-      "resolved": "https://registry.npmjs.org/modern-tar/-/modern-tar-0.7.7.tgz",
-      "integrity": "sha512-t9VmxaqrmANnEOBhpSDI6HD192Ge48k8vmWqQQL7hSFEqHEYwZbbsu49+aKLWZeRvFs3j1pMhXOqqF4kPlvjkQ==",
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/modern-tar/-/modern-tar-0.8.4.tgz",
+      "integrity": "sha512-gN54ddmyzEg10orwZ2u4OOv+bjpMWdIl5jIkodK97bMq8QBSL5c0D7YX0lT1Ooz+99S7+PvFbnxzdjgHo1r41g==",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
@@ -959,12 +878,12 @@
       }
     },
     "node_modules/puppeteer-core": {
-      "version": "25.4.0",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-25.4.0.tgz",
-      "integrity": "sha512-K1plkLOdeoUnGeT1OvdqF3qxl33v+Ra/uH5VyPEhXdMcpvGiEskHzxxEU3fgpccJpJLIipB/rPUsvkZRWeKqOA==",
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-25.6.0.tgz",
+      "integrity": "sha512-GJ67rjZdVQzZmD2Ab0cgttfQN9j387QYMv3t6MN3/4nmjursNt6M5Utj4/T/4y0AwNrSwJzjw6Q/zuWFEIizOg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@puppeteer/browsers": "3.0.6",
+        "@puppeteer/browsers": "3.2.0",
         "chromium-bidi": "17.0.2",
         "devtools-protocol": "0.0.1653615",
         "typed-query-selector": "^2.12.2",
@@ -1182,25 +1101,6 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
     },
-    "node_modules/section-matter": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
-      "integrity": "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==",
-      "license": "MIT",
-      "dependencies": {
-        "extend-shallow": "^2.0.1",
-        "kind-of": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-      "license": "BSD-3-Clause"
-    },
     "node_modules/string_decoder": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
@@ -1239,15 +1139,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
-    "node_modules/strip-bom-string": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
-      "integrity": "sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/typed-query-selector": {
@@ -1384,6 +1275,21 @@
       "license": "ISC",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/yargs": {

--- a/package.json
+++ b/package.json
@@ -13,12 +13,10 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@puppeteer/browsers": "^3.0.6",
-    "cheerio": "^1.0.0-rc.12",
+    "cheerio": "^1.2.0",
     "emoji-images": "^0.1.1",
-    "gray-matter": "^4.0.2",
-    "highlight.js": "^11.11.1",
-    "markdown-it": "^14.2.0",
+    "highlight.js": "^11.12.0",
+    "markdown-it": "^14.3.0",
     "markdown-it-checkbox": "^1.1.0",
     "markdown-it-container": "^2.0.0",
     "markdown-it-emoji": "^1.4.0",
@@ -26,8 +24,9 @@
     "markdown-it-plantuml": "^1.4.1",
     "mkdirp": "^1.0.3",
     "mustache": "^4.0.1",
-    "puppeteer-core": "^25.4.0",
+    "puppeteer-core": "^25.6.0",
     "puppeteer-core-v2": "npm:puppeteer-core@2.1.1",
-    "rimraf": "^6.1.3"
+    "rimraf": "^6.1.3",
+    "yaml": "^2.8.1"
   }
 }

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -83,3 +83,20 @@ test('normalizes browser variants and numeric helpers', () => {
   assert.equal(cli.normalizeDimension('  '), undefined);
   assert.equal(cli.setBooleanValue(false, true), false);
 });
+
+test('parses YAML front matter and preserves Markdown content', () => {
+  assert.deepEqual(
+    cli.parseFrontMatter('---\r\nbreaks: true\r\nnested:\r\n  enabled: false\r\n---\r\n# Title'),
+    {
+      data: { breaks: true, nested: { enabled: false } },
+      content: '# Title'
+    }
+  );
+});
+
+test('leaves Markdown without front matter unchanged', () => {
+  assert.deepEqual(cli.parseFrontMatter('# Title'), {
+    data: {},
+    content: '# Title'
+  });
+});


### PR DESCRIPTION
## Summary
- replace `gray-matter` with a YAML-based front matter parser
- remove the direct `@puppeteer/browsers` dependency and add `yaml`
- update `cheerio`, `puppeteer-core`, `markdown-it`, and `highlight.js`
- add front matter parsing tests

## Validation
- `npm test`